### PR TITLE
Add support for login via email or username

### DIFF
--- a/src/Enum/LoginField.php
+++ b/src/Enum/LoginField.php
@@ -6,4 +6,5 @@ enum LoginField
 {
     case Email;
     case Username;
+    case EmailOrUsername;
 }

--- a/src/Service/UsersService.php
+++ b/src/Service/UsersService.php
@@ -105,9 +105,11 @@ class UsersService implements UsersServiceInterface
 
     public function getLoginValue(UserModel $user): ?string
     {
-        return $this->loginField === LoginField::Email
-            ? $user->getEmail()
-            : $user->getUsername();
+        return match($this->loginField) {
+            LoginField::Email => $user->getEmail(),
+            LoginField::Username => $user->getUsername(),
+            LoginField::EmailOrUsername => $user->getUsername() ?? $user->getEmail(),
+        };
     }
 
     /**
@@ -258,9 +260,11 @@ class UsersService implements UsersServiceInterface
     #[\Override]
     public function getByLogin(string $login): ?UserModel
     {
-        return $this->loginField === LoginField::Email
-            ? $this->getByEmail($login)
-            : $this->getByUsername($login);
+        return match($this->loginField) {
+            LoginField::Email => $this->getByEmail($login),
+            LoginField::Username => $this->getByUsername($login),
+            LoginField::EmailOrUsername => $this->getByUsername($login) ?? $this->getByEmail($login),
+        };
     }
 
     /**

--- a/tests/TestUsersBase.php
+++ b/tests/TestUsersBase.php
@@ -31,7 +31,7 @@ abstract class TestUsersBase extends TestCase
     {
         return match ($this->loginField) {
             LoginField::Email => $forEmail,
-            LoginField::Username => $forUsername,
+            LoginField::Username, LoginField::EmailOrUsername => $forUsername,
         };
     }
 

--- a/tests/UsersDBDatasetByEmailOrUsernameTest.php
+++ b/tests/UsersDBDatasetByEmailOrUsernameTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests;
+
+use ByJG\Authenticate\Enum\LoginField;
+
+class UsersDBDatasetByEmailOrUsernameTest extends UsersDBDatasetByUsernameTestUsersBase
+{
+    #[\Override]
+    public function setUp(): void
+    {
+        $this->__setUp(LoginField::EmailOrUsername);
+    }
+
+    #[\Override]
+    public function testIsValidUser(): void
+    {
+        // Both username and email must work
+        $user = $this->object->isValidUser('user3', 'pwd3');
+        $this->assertEquals('User 3', $user->getName());
+
+        $user = $this->object->isValidUser('user3@gmail.com', 'pwd3');
+        $this->assertEquals('User 3', $user->getName());
+
+        // Wrong password returns null regardless of field used
+        $this->assertNull($this->object->isValidUser('user3', 'wrongpwd'));
+        $this->assertNull($this->object->isValidUser('user3@gmail.com', 'wrongpwd'));
+
+        // Non-existent identifier returns null
+        $this->assertNull($this->object->isValidUser('nonexistent', 'pwd3'));
+    }
+
+    public function testGetByLoginWithUsername(): void
+    {
+        $user = $this->object->getByLogin('user1');
+        $this->assertNotNull($user);
+        $this->assertEquals('User 1', $user->getName());
+        $this->assertEquals('user1', $user->getUsername());
+    }
+
+    public function testGetByLoginWithEmail(): void
+    {
+        $user = $this->object->getByLogin('user1@gmail.com');
+        $this->assertNotNull($user);
+        $this->assertEquals('User 1', $user->getName());
+        $this->assertEquals('user1@gmail.com', $user->getEmail());
+    }
+
+    public function testGetLoginValueReturnsUsername(): void
+    {
+        $user = $this->object->getByLogin('user2');
+        $this->assertEquals('user2', $this->object->getLoginValue($user));
+    }
+
+    public function testGetLoginFieldIsEmailOrUsername(): void
+    {
+        $this->assertEquals(LoginField::EmailOrUsername, $this->object->getLoginField());
+    }
+}


### PR DESCRIPTION
```markdown
### Description

This pull request introduces the `LoginField::EmailOrUsername` functionality, allowing users to log in using either their email address or username. This enhancement improves flexibility and user convenience in the login process.

### Changes

- Added `LoginField::EmailOrUsername`.
  
### Checklist

- [ ] Tests added for the new functionality
- [ ] Documentation updated, if applicable
```